### PR TITLE
Add missing parenthesis to `cache_get_value_name`

### DIFF
--- a/snippets/functions-community.json
+++ b/snippets/functions-community.json
@@ -943,7 +943,7 @@
     "cache_get_value_name": {
         "prefix": "cache_get_value_name",
         "body":
-            "cache_get_value_name(${1:row_idx}, ${2:const column_name[]}, ${3:destination[]}, ${4:max_len = sizeof(destination})$0"
+            "cache_get_value_name(${1:row_idx}, ${2:const column_name[]}, ${3:destination[]}, ${4:max_len = sizeof(destination)})$0"
     },
     "cache_get_value_name_int": {
         "prefix": "cache_get_value_name_int",


### PR DESCRIPTION
Fixes #32