### PR TITLE
feat: support plain function parsing

### DIFF
--- a/src/server/function.ts
+++ b/src/server/function.ts
@@ -24,7 +24,7 @@ export interface FindFunctionIdentifierResult {
 export let functionTokens: Map<string, PawnFunction> = new Map();
 
 export const parseFunctions = (textDocument: TextDocument) => {
-  const regex = /^(forward|native|stock)\s(.*?)\((.*?)\)/gm;
+  const regex = /^(?:(forward|native|stock)\s+)?(\S+)\((.*?)\)/gm;
   const content = textDocument.getText();
   const splitContent = content.split("\n");
   splitContent.forEach((cont: string, index: number) => {


### PR DESCRIPTION
This PR implements #26.
The updated regex preserves the original regex groups order, so all the parsing logic should work without further changes.

![image](https://user-images.githubusercontent.com/34796192/183242870-0475c6e1-c87a-4a11-917f-fd1b012bb869.png)
