### PR TITLE
Remove package to support latest sampctl version

### DIFF
--- a/src/tasks.json
+++ b/src/tasks.json
@@ -20,7 +20,7 @@
         {
             "label": "build only",
             "type": "shell",
-            "command": "sampctl package build",
+            "command": "sampctl build",
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -35,7 +35,7 @@
         {
             "label": "build watcher",
             "type": "shell",
-            "command": "sampctl package build --watch",
+            "command": "sampctl build --watch",
             "group": "build",
             "isBackground": true,
             "presentation": {
@@ -47,7 +47,7 @@
         {
             "label": "run tests",
             "type": "shell",
-            "command": "sampctl package run",
+            "command": "sampctl run",
             "group": {
                 "kind": "test",
                 "isDefault": true
@@ -62,7 +62,7 @@
         {
             "label": "run tests watcher",
             "type": "shell",
-            "command": "sampctl package run --watch",
+            "command": "sampctl run --watch",
             "group": "test",
             "isBackground": true,
             "presentation": {


### PR DESCRIPTION
Starting from sampctl v1.11.0, it's no longer using `package` anymore, this PR removes it and encouraging people to update their sampctl to latest version.